### PR TITLE
Fix empty reads

### DIFF
--- a/cmd/satellite/server/server.go
+++ b/cmd/satellite/server/server.go
@@ -165,7 +165,7 @@ func (fso *DockerFuseFSOps) Read(request rpccommon.ReadRequest, reply *rpccommon
 
 	data := make([]byte, request.Num)
 	n, err := file.ReadAt(data, request.Offset)
-	if err != nil {
+	if err != nil && (err.Error() != "EOF" || n <= 0) {
 		return rpccommon.ErrnoToRPCErrorString(err)
 	}
 


### PR DESCRIPTION
Fist of all , I believe this is a very much needed tool for developers and I would be happy to see this released as a docker plugin :) 

I tried to play with it but stuck with an error. All my attempts to read content of the file were failing. I am using go 1.18.1 and it turns out File.ReadAt function always return EOF error if data read from the file is less than the allocated buffer size (docs https://go.dev/src/os/file.go?s=7686:7723)

I had to tweak error handler to let the data be returned in that special case