### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# DockerFuse: interact with filesystem of Linux Docker containters, via FUSE
+# DockerFuse: interact with filesystem of Linux Docker containers, via FUSE
 
 [![license](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0) [![go report card](https://goreportcard.com/badge/github.com/dguerri/dockerfuse)](https://goreportcard.com/report/github.com/dguerri/dockerfuse) [![CI](https://github.com/dguerri/dockerfuse/actions/workflows/run-CI.yml/badge.svg)](https://github.com/dguerri/dockerfuse/actions/workflows/run-CI.yml) [![coverage status](https://coveralls.io/repos/github/dguerri/dockerfuse/badge.svg?branch=main)](https://coveralls.io/github/dguerri/dockerfuse?branch=main)
 


### PR DESCRIPTION
## Summary
- fix a typo in the README intro line

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_687b5122b6248323a9260e658d8913ee