### PR TITLE
Fix comment in rpc client

### DIFF
--- a/cmd/dockerfuse/client/rcp_client.go
+++ b/cmd/dockerfuse/client/rcp_client.go
@@ -16,7 +16,7 @@ type rpcClient interface {
 	Close() error
 }
 
-// rpcCL implements rpcClientFactoryInterface providing real RPC communication
+// rpcClientFactory implements rpcClientFactoryInterface providing real RPC communication
 type rpcClientFactory struct{}
 
 func (*rpcClientFactory) NewClient(conn io.ReadWriteCloser) rpcClient { return rpc.NewClient(conn) }


### PR DESCRIPTION
## Summary
- update comment to reference `rpcClientFactory`

## Testing
- `gofmt -w cmd/dockerfuse/client/rcp_client.go`

------
https://chatgpt.com/codex/tasks/task_e_687b516da13483239c5bc78ad5af1ec0