### PR TITLE
Add documentation for exported items

### DIFF
--- a/cmd/dockerfuse/main.go
+++ b/cmd/dockerfuse/main.go
@@ -31,7 +31,7 @@ const (
 	errorDaemon           = 2
 	errorCreateMount      = 3
 	errorGetUser          = 4
-	errorInvalidUidGid    = 5
+	errorInvalidUIDGid    = 5
 	errorInitDockerClient = 6
 	errorMountUnmount     = 7
 )
@@ -138,12 +138,12 @@ func main() {
 	uid, err := strconv.Atoi(user.Uid)
 	if err != nil {
 		slog.Error("invalid uid", "uid", user.Uid, "error", err)
-		os.Exit(errorInvalidUidGid)
+		os.Exit(errorInvalidUIDGid)
 	}
 	gid, err := strconv.Atoi(user.Gid)
 	if err != nil {
 		slog.Error("invalid gid", "gid", user.Gid, "error", err)
-		os.Exit(errorInvalidUidGid)
+		os.Exit(errorInvalidUIDGid)
 	}
 
 	fuseDockerClient, err := client.NewDockerFuseClient(containerID)

--- a/cmd/satellite/server/server.go
+++ b/cmd/satellite/server/server.go
@@ -24,6 +24,7 @@ func NewDockerFuseFSOps() (fso *DockerFuseFSOps) {
 	}
 }
 
+// CloseAllFDs closes all file descriptors currently opened by the server.
 func (fso *DockerFuseFSOps) CloseAllFDs() {
 	for k, fd := range fso.fds {
 		fd.Close()
@@ -31,6 +32,7 @@ func (fso *DockerFuseFSOps) CloseAllFDs() {
 	}
 }
 
+// Stat returns file information about the requested path.
 func (fso *DockerFuseFSOps) Stat(request rpccommon.StatRequest, reply *rpccommon.StatReply) error {
 	log.Printf("Stat called: %v", request)
 
@@ -62,6 +64,7 @@ func (fso *DockerFuseFSOps) Stat(request rpccommon.StatRequest, reply *rpccommon
 	return nil
 }
 
+// ReadDir lists the contents of a directory.
 func (fso *DockerFuseFSOps) ReadDir(request rpccommon.ReadDirRequest, reply *rpccommon.ReadDirReply) error {
 	log.Printf("ReadDir called: %v", request)
 
@@ -92,6 +95,7 @@ func (fso *DockerFuseFSOps) ReadDir(request rpccommon.ReadDirRequest, reply *rpc
 	return nil
 }
 
+// Open opens the requested file and stores the resulting descriptor.
 func (fso *DockerFuseFSOps) Open(request rpccommon.OpenRequest, reply *rpccommon.OpenReply) error {
 	log.Printf("Open called: %v", request)
 
@@ -131,6 +135,7 @@ func (fso *DockerFuseFSOps) Open(request rpccommon.OpenRequest, reply *rpccommon
 	return nil
 }
 
+// Close closes an open file descriptor previously returned by Open.
 func (fso *DockerFuseFSOps) Close(request rpccommon.CloseRequest, reply *rpccommon.CloseReply) error {
 	log.Printf("Close called: %v", request)
 
@@ -147,6 +152,7 @@ func (fso *DockerFuseFSOps) Close(request rpccommon.CloseRequest, reply *rpccomm
 	return nil
 }
 
+// Read reads data from an open file descriptor.
 func (fso *DockerFuseFSOps) Read(request rpccommon.ReadRequest, reply *rpccommon.ReadReply) error {
 	log.Printf("Read called: %v", request)
 
@@ -165,6 +171,7 @@ func (fso *DockerFuseFSOps) Read(request rpccommon.ReadRequest, reply *rpccommon
 	return nil
 }
 
+// Seek moves the file offset associated with a descriptor.
 func (fso *DockerFuseFSOps) Seek(request rpccommon.SeekRequest, reply *rpccommon.SeekReply) error {
 	log.Printf("Seek called: %v", request)
 
@@ -182,6 +189,7 @@ func (fso *DockerFuseFSOps) Seek(request rpccommon.SeekRequest, reply *rpccommon
 	return nil
 }
 
+// Write writes data to an open file descriptor.
 func (fso *DockerFuseFSOps) Write(request rpccommon.WriteRequest, reply *rpccommon.WriteReply) error {
 	log.Printf("Write called: %v", request)
 
@@ -199,6 +207,7 @@ func (fso *DockerFuseFSOps) Write(request rpccommon.WriteRequest, reply *rpccomm
 	return nil
 }
 
+// Unlink removes a file from the filesystem.
 func (fso *DockerFuseFSOps) Unlink(request rpccommon.UnlinkRequest, reply *rpccommon.UnlinkReply) error {
 	log.Printf("Unlink called: %v", request)
 
@@ -209,6 +218,7 @@ func (fso *DockerFuseFSOps) Unlink(request rpccommon.UnlinkRequest, reply *rpcco
 	return nil
 }
 
+// Fsync flushes pending file changes to disk.
 func (fso *DockerFuseFSOps) Fsync(request rpccommon.FsyncRequest, reply *rpccommon.FsyncReply) error {
 	log.Printf("Fsync called: %v", request)
 
@@ -224,6 +234,7 @@ func (fso *DockerFuseFSOps) Fsync(request rpccommon.FsyncRequest, reply *rpccomm
 	return nil
 }
 
+// Mkdir creates a new directory.
 func (fso *DockerFuseFSOps) Mkdir(request rpccommon.MkdirRequest, reply *rpccommon.MkdirReply) error {
 	log.Printf("Mkdir called: %v", request)
 
@@ -239,6 +250,7 @@ func (fso *DockerFuseFSOps) Mkdir(request rpccommon.MkdirRequest, reply *rpccomm
 	return nil
 }
 
+// Rmdir removes a directory from the filesystem.
 func (fso *DockerFuseFSOps) Rmdir(request rpccommon.RmdirRequest, reply *rpccommon.RmdirReply) error {
 	log.Printf("Rmdir called: %v", request)
 
@@ -249,6 +261,7 @@ func (fso *DockerFuseFSOps) Rmdir(request rpccommon.RmdirRequest, reply *rpccomm
 	return nil
 }
 
+// Rename renames a file or directory.
 func (fso *DockerFuseFSOps) Rename(request rpccommon.RenameRequest, reply *rpccommon.RenameReply) error {
 	log.Printf("Rename called: %v", request)
 
@@ -260,6 +273,7 @@ func (fso *DockerFuseFSOps) Rename(request rpccommon.RenameRequest, reply *rpcco
 	return nil
 }
 
+// Readlink returns the target of a symbolic link.
 func (fso *DockerFuseFSOps) Readlink(request rpccommon.ReadlinkRequest, reply *rpccommon.ReadlinkReply) error {
 	log.Printf("Readlink called: %v", request)
 
@@ -271,6 +285,7 @@ func (fso *DockerFuseFSOps) Readlink(request rpccommon.ReadlinkRequest, reply *r
 	return nil
 }
 
+// Link creates a new hard link.
 func (fso *DockerFuseFSOps) Link(request rpccommon.LinkRequest, reply *rpccommon.LinkReply) error {
 	log.Printf("Link called: %v", request)
 
@@ -282,6 +297,7 @@ func (fso *DockerFuseFSOps) Link(request rpccommon.LinkRequest, reply *rpccommon
 	return nil
 }
 
+// Symlink creates a new symbolic link.
 func (fso *DockerFuseFSOps) Symlink(request rpccommon.SymlinkRequest, reply *rpccommon.SymlinkReply) error {
 	log.Printf("Symlink called: %v", request)
 
@@ -293,6 +309,7 @@ func (fso *DockerFuseFSOps) Symlink(request rpccommon.SymlinkRequest, reply *rpc
 	return nil
 }
 
+// SetAttr changes file attributes like mode, owner or timestamps.
 func (fso *DockerFuseFSOps) SetAttr(request rpccommon.SetAttrRequest, reply *rpccommon.SetAttrReply) (err error) {
 	log.Printf("SetAttr called: %v", request)
 

--- a/pkg/rpccommon/rpc_types.go
+++ b/pkg/rpccommon/rpc_types.go
@@ -12,16 +12,22 @@ type DirEntry struct {
 	Ino  uint64
 }
 
+// ReadDirRequest describes a request to read a directory.
 type ReadDirRequest struct {
 	FullPath string
 }
+
+// ReadDirReply is the reply to a ReadDirRequest.
 type ReadDirReply struct {
 	DirEntries []DirEntry
 }
 
+// StatRequest contains the path information for a stat call.
 type StatRequest struct {
 	FullPath string
 }
+
+// StatReply mirrors os.Stat results returned via RPC.
 type StatReply struct {
 	Mode       uint32
 	Nlink      uint32
@@ -37,106 +43,155 @@ type StatReply struct {
 	LinkTarget string
 }
 
+// OpenRequest represents an open file request.
 type OpenRequest struct {
 	FullPath string
 	SAFlags  uint16 // System-agnostic flags
 	Mode     os.FileMode
 }
+
+// OpenReply contains information about the opened file.
 type OpenReply struct {
 	FD uintptr
 	StatReply
 }
 
+// CloseRequest identifies a file descriptor to close.
 type CloseRequest struct {
 	FD uintptr
 }
+
+// CloseReply is returned on a successful close.
 type CloseReply struct{}
 
+// ReadRequest represents a remote read request.
 type ReadRequest struct {
 	FD     uintptr
 	Offset int64
 	Num    int
 }
+
+// ReadReply contains the bytes read from a file.
 type ReadReply struct {
 	Data []byte
 }
 
+// SeekRequest represents a seek operation on a file.
 type SeekRequest struct {
 	FD     uintptr
 	Offset int64
 	Whence int
 }
+
+// SeekReply carries the resulting offset after a seek.
 type SeekReply struct {
 	Num int64
 }
 
+// WriteRequest represents a write operation.
 type WriteRequest struct {
 	FD     uintptr
 	Offset int64
 	Data   []byte
 }
+
+// WriteReply contains the number of bytes written.
 type WriteReply struct {
 	Num int
 }
 
+// UnlinkRequest specifies the path of the file to remove.
 type UnlinkRequest struct {
 	FullPath string
 }
+
+// UnlinkReply is returned on a successful unlink.
 type UnlinkReply struct{}
 
+// FsyncRequest represents a fsync call.
 type FsyncRequest struct {
 	FD    uintptr
 	Flags uint32
 }
+
+// FsyncReply is returned on a successful fsync.
 type FsyncReply struct{}
 
+// MkdirRequest represents a directory creation request.
 type MkdirRequest struct {
 	FullPath string
 	Mode     os.FileMode
 }
+
+// MkdirReply contains attributes of the newly created directory.
 type MkdirReply StatReply
 
+// RmdirRequest identifies the directory to remove.
 type RmdirRequest struct {
 	FullPath string
 }
+
+// RmdirReply is returned on a successful rmdir.
 type RmdirReply struct{}
 
+// RenameRequest contains old and new names for a rename operation.
 type RenameRequest struct {
 	FullPath    string
 	FullNewPath string
 	Flags       uint32
 }
+
+// RenameReply is returned on a successful rename.
 type RenameReply struct{}
 
+// ReadlinkRequest represents a request to read a symbolic link.
 type ReadlinkRequest struct {
 	FullPath string
 }
+
+// ReadlinkReply contains the target of a symbolic link.
 type ReadlinkReply struct {
 	LinkTarget string
 }
 
+// LinkRequest represents a hard link creation request.
 type LinkRequest struct {
 	OldFullPath string
 	NewFullPath string
 }
+
+// LinkReply is returned on a successful link call.
 type LinkReply struct{}
 
+// SymlinkRequest contains paths for creating a symbolic link.
 type SymlinkRequest struct {
 	OldFullPath string
 	NewFullPath string
 }
+
+// SymlinkReply is returned on a successful symlink call.
 type SymlinkReply struct{}
 
-const ( // bitmap for SetAttrRequest.ValidAttrs
+// Bitmap values used by SetAttrRequest.ValidAttrs.
+const (
+	// SATTR_ATIME indicates ATime should be updated.
 	SATTR_ATIME = (1 << 0)
-	SATTR_GID   = (1 << 1)
-	SATTR_MODE  = (1 << 2)
+	// SATTR_GID indicates GID should be updated.
+	SATTR_GID = (1 << 1)
+	// SATTR_MODE indicates Mode should be updated.
+	SATTR_MODE = (1 << 2)
+	// SATTR_MTIME indicates MTime should be updated.
 	SATTR_MTIME = (1 << 3)
-	SATTR_SIZE  = (1 << 4)
-	SATTR_UID   = (1 << 5)
+	// SATTR_SIZE indicates Size should be updated.
+	SATTR_SIZE = (1 << 4)
+	// SATTR_UID indicates UID should be updated.
+	SATTR_UID = (1 << 5)
 )
+
+// UTIME_OMIT is used with utimensat() to leave a timestamp unchanged.
 const UTIME_OMIT = ((1 << 30) - 2)
 
+// SetAttrRequest describes which attributes of a file should be changed.
 type SetAttrRequest struct {
 	FullPath   string
 	ValidAttrs uint32 // See SATTR_* bitmap
@@ -147,38 +202,51 @@ type SetAttrRequest struct {
 	Mode       uint32
 	Size       uint64
 }
+
+// SetAttrReply contains the updated attributes of the file.
 type SetAttrReply StatReply
 
+// GetMode returns the Mode if it was requested to be set.
 func (r *SetAttrRequest) GetMode() (m uint32, ok bool) {
 	if r.ValidAttrs&SATTR_MODE == SATTR_MODE {
 		return r.Mode, true
 	}
 	return 0, false
 }
+
+// GetUID returns the UID if it was requested to be set.
 func (r *SetAttrRequest) GetUID() (u uint32, ok bool) {
 	if r.ValidAttrs&SATTR_UID == SATTR_UID {
 		return r.UID, true
 	}
 	return 0, false
 }
+
+// GetGID returns the GID if it was requested to be set.
 func (r *SetAttrRequest) GetGID() (g uint32, ok bool) {
 	if r.ValidAttrs&SATTR_GID == SATTR_GID {
 		return r.GID, true
 	}
 	return 0, false
 }
+
+// GetATime returns the access time if it was requested to be set.
 func (r *SetAttrRequest) GetATime() (m time.Time, ok bool) {
 	if r.ValidAttrs&SATTR_ATIME == SATTR_ATIME {
 		return r.ATime, true
 	}
 	return time.Time{}, false
 }
+
+// GetMTime returns the modification time if it was requested to be set.
 func (r *SetAttrRequest) GetMTime() (m time.Time, ok bool) {
 	if r.ValidAttrs&SATTR_MTIME == SATTR_MTIME {
 		return r.MTime, true
 	}
 	return time.Time{}, false
 }
+
+// GetSize returns the Size if it was requested to be set.
 func (r *SetAttrRequest) GetSize() (m uint64, ok bool) {
 	if r.ValidAttrs&SATTR_SIZE == SATTR_SIZE {
 		return r.Size, true
@@ -186,9 +254,20 @@ func (r *SetAttrRequest) GetSize() (m uint64, ok bool) {
 	return 0, false
 }
 
-func (r *SetAttrRequest) SetMode(m uint32)     { r.Mode = m; r.ValidAttrs |= SATTR_MODE }
-func (r *SetAttrRequest) SetUID(u uint32)      { r.UID = u; r.ValidAttrs |= SATTR_UID }
-func (r *SetAttrRequest) SetGID(g uint32)      { r.GID = g; r.ValidAttrs |= SATTR_GID }
+// SetMode marks Mode as valid and sets it.
+func (r *SetAttrRequest) SetMode(m uint32) { r.Mode = m; r.ValidAttrs |= SATTR_MODE }
+
+// SetUID marks UID as valid and sets it.
+func (r *SetAttrRequest) SetUID(u uint32) { r.UID = u; r.ValidAttrs |= SATTR_UID }
+
+// SetGID marks GID as valid and sets it.
+func (r *SetAttrRequest) SetGID(g uint32) { r.GID = g; r.ValidAttrs |= SATTR_GID }
+
+// SetATime marks ATime as valid and sets it.
 func (r *SetAttrRequest) SetATime(a time.Time) { r.ATime = a; r.ValidAttrs |= SATTR_ATIME }
+
+// SetMTime marks MTime as valid and sets it.
 func (r *SetAttrRequest) SetMTime(m time.Time) { r.MTime = m; r.ValidAttrs |= SATTR_MTIME }
-func (r *SetAttrRequest) SetSize(s uint64)     { r.Size = s; r.ValidAttrs |= SATTR_SIZE }
+
+// SetSize marks Size as valid and sets it.
+func (r *SetAttrRequest) SetSize(s uint64) { r.Size = s; r.ValidAttrs |= SATTR_SIZE }


### PR DESCRIPTION
## Summary
- add missing comments to exported structs, methods and constants
- rename `errorInvalidUidGid` to `errorInvalidUIDGid`

## Testing
- `go vet ./...`


------
https://chatgpt.com/codex/tasks/task_e_687b98d13890832395099b99bcafd210